### PR TITLE
 Use $this and not unknown variable $configuration

### DIFF
--- a/src/HipexDeployConfiguration/Configuration/Magento2.php
+++ b/src/HipexDeployConfiguration/Configuration/Magento2.php
@@ -52,7 +52,7 @@ class Magento2 extends Configuration
             'pub/media',
         ]);
 
-        $configuration->setDeployExclude([
+        $this->setDeployExclude([
             'setup/',
             'phpserver/',
             'docker/',


### PR DESCRIPTION
An unknown variable $configuration was used in \HipexDeployConfiguration\Configuration\Magento2::initializeDefaultConfiguration