### PR TITLE
Added extra cache flush before running setup:upgrade

### DIFF
--- a/src/HipexDeployConfiguration/Configuration/Magento2.php
+++ b/src/HipexDeployConfiguration/Configuration/Magento2.php
@@ -40,6 +40,7 @@ class Magento2 extends Configuration
         $this->addBuildCommand(new Command\Build\Magento2\SetupStaticContentDeploy($localesBackend, 'adminhtml'));
 
         $this->addDeployCommand(new Command\Deploy\Magento2\MaintenanceMode());
+        $this->addDeployCommand(new Command\Deploy\Magento2\CacheFlush());
         $this->addDeployCommand(new Command\Deploy\Magento2\SetupUpgrade());
         $this->addDeployCommand(new Command\Deploy\Magento2\CacheFlush());
 


### PR DESCRIPTION
Since some servers use code caching, we need to clear the cache before we can actually use setup:upgrade. We ran into an issue where there we deleted a class which could not be found in the setup:upgrade. A cache flush before the setup:upgrade fixes this.